### PR TITLE
Fix issues downloading vale binary on windows

### DIFF
--- a/vale/main.py
+++ b/vale/main.py
@@ -73,7 +73,9 @@ def get_target() -> (str, str, str):
     return operating_system, architecture, extension
 
 
-def extract_vale(archive: str, archive_type: str, destination: str) -> str:
+def extract_vale(
+    archive: str, archive_type: str, destination: str, bin_name: str = "vale"
+) -> str:
     """Extract `vale` binary from the given archive."""
     if archive_type == "zip":
         archiver = zipfile.ZipFile(archive)
@@ -86,7 +88,7 @@ def extract_vale(archive: str, archive_type: str, destination: str) -> str:
     with archiver(archive) as archive_volume:
         archive_volume.extractall(destination)
 
-    vale_tmp_path = Path(destination) / "vale"
+    vale_tmp_path = Path(destination) / bin_name
 
     assert (vale_tmp_path.exists())
 
@@ -121,7 +123,8 @@ def download_vale_if_missing() -> str:
 
             with tempfile.TemporaryDirectory() as td:
 
-                vale_tmp_path = extract_vale(tp.name, extension, td)
+                archive_bin_name = "vale.exe" if operating_system == "Windows" else "vale"
+                vale_tmp_path = extract_vale(tp.name, extension, td, archive_bin_name)
 
                 print(f"* Copying {vale_tmp_path} to {vale_bin_path}")
                 shutil.copy(f"{vale_tmp_path}", f"{vale_bin_path}")

--- a/vale/main.py
+++ b/vale/main.py
@@ -115,7 +115,8 @@ def download_vale_if_missing() -> str:
 
         url = urlopen(url)
 
-        with tempfile.NamedTemporaryFile(mode="w+b") as tp:
+        # delete=False is required to avoid permissions errors on windows
+        with tempfile.NamedTemporaryFile(mode="w+b", delete=False) as tp:
 
             tp.write(url.read())
 
@@ -128,6 +129,12 @@ def download_vale_if_missing() -> str:
 
                 print(f"* Copying {vale_tmp_path} to {vale_bin_path}")
                 shutil.copy(f"{vale_tmp_path}", f"{vale_bin_path}")
+
+        # clean up the temp file if it still exists
+        try:
+            os.unlink(tp.name)
+        except Exception:
+            pass
 
         print("* vale extracted and copied to module path.")
 

--- a/vale/main.py
+++ b/vale/main.py
@@ -78,7 +78,7 @@ def extract_vale(
 ) -> str:
     """Extract `vale` binary from the given archive."""
     if archive_type == "zip":
-        archiver = zipfile.ZipFile(archive)
+        archiver = zipfile.ZipFile
     elif archive_type == "tar.gz":
         archiver = partial(tarfile.open, mode="r:gz")
     else:

--- a/vale/main.py
+++ b/vale/main.py
@@ -2,6 +2,7 @@
 """Downloads Vale if not downloaded yet and executes it."""
 
 import os
+import platform
 import shutil
 import sys
 import tarfile
@@ -45,7 +46,10 @@ def get_target() -> (str, str, str):
     elif sys.platform.startswith("win32"):
         operating_system = "Windows"
 
-    if os.uname().machine.startswith("x86_64"):
+    if operating_system == "Windows":
+        convert_arch = {"32bit": "32-bit", "64bit": "64-bit"}
+        architecture = convert_arch.get(platform.architecture()[0], None)
+    elif os.uname().machine.startswith("x86_64"):
         architecture = "64-bit"
     elif os.uname().machine.startswith("arm"):
         # This is a loose match. Theoretical valid values:


### PR DESCRIPTION
This PR fixes a few issues found when trying to use the vale python package on windows.:
- #4
- #5 
- #6 

#4 and #5 are relatively straightforward, but the fix for the temp file problem in #6 is a bit ugly. 

Apologies for opening the PR without discussing it much first, I kept hitting a different problem after resolving one of them so I thought it would be cleaner if I got it working first. I'm guessing that there's a chance that not many users run this on windows, so it could be difficult for the maintainers to test?

I'd welcome any feedback about the workarounds, or any style problems. 