### PR TITLE
Fix windows binary .exe problem

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include vale/vale_bin
+include vale/vale.exe

--- a/vale/main.py
+++ b/vale/main.py
@@ -73,7 +73,9 @@ def get_target() -> (str, str, str):
     return operating_system, architecture, extension
 
 
-def extract_vale(archive: str, archive_type: str, destination: str) -> str:
+def extract_vale(
+    archive: str, archive_type: str, destination: str, bin_name: str = "vale"
+) -> str:
     """Extract `vale` binary from the given archive."""
     if archive_type == "zip":
         archiver = zipfile.ZipFile(archive)
@@ -86,7 +88,7 @@ def extract_vale(archive: str, archive_type: str, destination: str) -> str:
     with archiver(archive) as archive_volume:
         archive_volume.extractall(destination)
 
-    vale_tmp_path = Path(destination) / "vale"
+    vale_tmp_path = Path(destination) / bin_name
 
     assert (vale_tmp_path.exists())
 
@@ -121,7 +123,8 @@ def download_vale_if_missing() -> str:
 
             with tempfile.TemporaryDirectory() as td:
 
-                vale_tmp_path = extract_vale(tp.name, extension, td)
+                archive_bin_name = "vale.exe" if operating_system == "Windows" else "vale"
+                vale_tmp_path = extract_vale(tp.name, extension, td, archive_bin_name)
 
                 print(f"* Copying {vale_tmp_path} to {vale_bin_path}")
                 shutil.copy(f"{vale_tmp_path}", f"{vale_bin_path}")

--- a/vale/main.py
+++ b/vale/main.py
@@ -115,7 +115,8 @@ def download_vale_if_missing() -> str:
 
         url = urlopen(url)
 
-        with tempfile.NamedTemporaryFile(mode="w+b") as tp:
+        # delete=False is required to avoid permissions errors on windows
+        with tempfile.NamedTemporaryFile(mode="w+b", delete=False) as tp:
 
             tp.write(url.read())
 
@@ -128,6 +129,12 @@ def download_vale_if_missing() -> str:
 
                 print(f"* Copying {vale_tmp_path} to {vale_bin_path}")
                 shutil.copy(f"{vale_tmp_path}", f"{vale_bin_path}")
+
+        # clean up the temp file if it still exists
+        try:
+            os.unlink(tp.name)
+        except Exception:
+            pass
 
         print("* vale extracted and copied to module path.")
 

--- a/vale/main.py
+++ b/vale/main.py
@@ -78,7 +78,7 @@ def extract_vale(
 ) -> str:
     """Extract `vale` binary from the given archive."""
     if archive_type == "zip":
-        archiver = zipfile.ZipFile(archive)
+        archiver = zipfile.ZipFile
     elif archive_type == "tar.gz":
         archiver = partial(tarfile.open, mode="r:gz")
     else:

--- a/vale/main.py
+++ b/vale/main.py
@@ -2,6 +2,7 @@
 """Downloads Vale if not downloaded yet and executes it."""
 
 import os
+import platform
 import shutil
 import sys
 import tarfile
@@ -45,7 +46,10 @@ def get_target() -> (str, str, str):
     elif sys.platform.startswith("win32"):
         operating_system = "Windows"
 
-    if os.uname().machine.startswith("x86_64"):
+    if operating_system == "Windows":
+        convert_arch = {"32bit": "32-bit", "64bit": "64-bit"}
+        architecture = convert_arch.get(platform.architecture()[0], None)
+    elif os.uname().machine.startswith("x86_64"):
         architecture = "64-bit"
     elif os.uname().machine.startswith("arm"):
         # This is a loose match. Theoretical valid values:

--- a/vale/main.py
+++ b/vale/main.py
@@ -97,7 +97,13 @@ def extract_vale(
 
 def download_vale_if_missing() -> str:
     """Download vale only if missing."""
-    vale_bin_path = Path(vale.__file__).parent / "vale_bin"
+
+    operating_system, architecture, extension = get_target()
+
+    if operating_system == "Windows":
+        vale_bin_path = Path(vale.__file__).parent / "vale.exe"
+    else:
+        vale_bin_path = Path(vale.__file__).parent / "vale_bin"
 
     # We have a dummy vale placeholder that is overwritten by the downloaded vale version.
     # See `vale/vale_bin` (in this repo, not in its installed form) for more details about
@@ -105,8 +111,6 @@ def download_vale_if_missing() -> str:
     if vale_bin_path.stat().st_size < 1000:
 
         print("* vale not found. Downloading it...")
-
-        operating_system, architecture, extension = get_target()
 
         url = ("https://github.com/errata-ai/vale/releases/download"
                f"/v{vale_bin_version}/"

--- a/vale/vale.exe
+++ b/vale/vale.exe
@@ -1,0 +1,6 @@
+This is a placeholder for the actual Vale binary (Windows exe).
+
+Having a placeholder will allow pip to remove this
+file if the package is uninstalled.
+
+If we find this placeholder, we download Vale's binary.


### PR DESCRIPTION
"Fixes" the issue where we can't run the vale binary on windows (#8 ).

However this adds a new "vale.exe" to the mainfest, which is not as clean than the original single vale_bin (which I assume was intended to be common to all platforms).

There might be other ways to deal with this, perhaps varying based on whether the user is running powershell or cmd.exe, but adding the .exe is probably the simplest solution.

I put this in a separate PR from #8 for now, since adding the .exe seems like a more invasive addition, but of course I'm happy to rearrange it however you prefer!