### PR TITLE
Use subprocess.run to run vale binary(#8)

### DIFF
--- a/vale/main.py
+++ b/vale/main.py
@@ -146,5 +146,5 @@ def main():
     """Download vale if not downloaded and executes it."""
     vale_bin_path = download_vale_if_missing()
 
-    ret_code = subprocess.call([f"{vale_bin_path}"] + sys.argv[1:])
-    sys.exit(ret_code)
+    proc = subprocess.run([f"{vale_bin_path}"] + sys.argv[1:])
+    sys.exit(proc.returncode)

--- a/vale/main.py
+++ b/vale/main.py
@@ -4,6 +4,7 @@
 import os
 import platform
 import shutil
+import subprocess
 import sys
 import tarfile
 import tempfile
@@ -145,4 +146,6 @@ def main():
     """Download vale if not downloaded and executes it."""
     vale_bin_path = download_vale_if_missing()
 
-    os.execvp(f"{vale_bin_path}", ["vale"] + sys.argv[1:])
+    proc = subprocess.Popen([f"{vale_bin_path}"] + sys.argv[1:])
+    ret_code = proc.wait()
+    sys.exit(ret_code)

--- a/vale/main.py
+++ b/vale/main.py
@@ -146,6 +146,5 @@ def main():
     """Download vale if not downloaded and executes it."""
     vale_bin_path = download_vale_if_missing()
 
-    proc = subprocess.Popen([f"{vale_bin_path}"] + sys.argv[1:])
-    ret_code = proc.wait()
+    ret_code = subprocess.call([f"{vale_bin_path}"] + sys.argv[1:])
     sys.exit(ret_code)


### PR DESCRIPTION
https://github.com/daniperez/vale-python-package/issues/8 execvp doesn't replace the active process on windows, so we use Popen and forward the return code instead.