### PR TITLE
Update to vale version 2.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,29 @@
-# 2.20.2.0
+# Changelog
+
+## 2.28.1.0
+
+- Using Vale v2.28.1
+
+## 2.20.2.0
+
 - Using Vale v2.20.2.
 
-# 2.20.1.0
+## 2.20.1.0
+
 - Releasing v2.20.1 of Vale.
 
-# 2.20.0.9
+## 2.20.0.9
+
 - Delivering package to Pypi (main).
 
-# 2.20.0.6
+## 2.20.0.6
+
 - Reverted "universal" wheel flag.
 
-# 2.20.0.5
+## 2.20.0.5
+
 - Parameters from vale_bin were not being correctly redirected to vale.
 
-# 2.20.0.1
+## 2.20.0.1
+
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -12,21 +12,23 @@ to allow Python users to have Vale as a dependency of a Python application or
 library and this way allow installing Vale without resorting to manual installation
 or similar.
 
-# Installation 
+## Installation
+
 You can add `vale` package as a dependency in your `setup.py`,
 `requirements.txt` or `pyproject.toml` file depending on how are you managing
 dependencies. For example, in `requirements.txt`:
 
+```shell
+vale==2.28.1
 ```
-vale==2.20.0
-``` 
 
 The version of this Python package corresponds exactly to Vale's version.  That
 is, if you add `vale==2.20.0` as a dependency, Vale with that same version will
 be installed.  Note that **Vale as such is not included in this package but
 downloaded the first time you execute `vale`**.
 
-# Releasing (only for contributors)
+## Releasing (only for contributors)
+
 1. Change version in `pyproject.toml`. Changing the version changes the
    version of Vale that gets downloaded. See note below.
 2. Commit & push.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name="vale"
 # account for fixes to this package. That 4th number is needed because PyPi
 # doesn't allow to re-release or upload deleted versions, every uploaded
 # version must be unique.
-version = "2.26.0.0"
+version = "2.28.1.0"
 authors = [
   { name="Dani Perez"},
 ]


### PR DESCRIPTION
I updated to vale 2.28.1 (latest version).
I saw that you were trying to automate the releasing. Have you thought about giving your code to the authors of vale? They could easily include your code and GitHub action. That would be great. We're using your pip package for our running vale on our (corporate) documentation for a data science platform.