### PR TITLE
Fix part of URL for ARM architecture

### DIFF
--- a/vale/main.py
+++ b/vale/main.py
@@ -48,7 +48,7 @@ def get_target() -> Tuple[str, str, str]:
         operating_system = "Windows"
 
     if platform.processor() == "arm":
-        architecture = "arm"
+        architecture = "arm64"
     else:
         convert_arch = {"32bit": "32-bit", "64bit": "64-bit"}
         architecture = convert_arch.get(platform.architecture()[0], None)


### PR DESCRIPTION
The part of the URL for the architecture should be `arm64`, instead of `arm`, per the [vale releases page](https://github.com/errata-ai/vale/releases/).

- https://github.com/errata-ai/vale/releases/download/v2.30.0/vale_2.30.0_Linux_arm64.tar.gz
- https://github.com/errata-ai/vale/releases/download/v2.30.0/vale_2.30.0_macOS_arm64.tar.gz
- https://github.com/errata-ai/vale/releases/download/v2.30.0/vale_2.30.0_Windows_arm64.zip

Fixes #28.

Thank you for this nice little package. This removes a manual installation step for the Plone documentation team.