### PR TITLE
Using a more recent python to avoid [1]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python 3.x
       uses: actions/setup-python@v3
       with:
-        python-version: "3.7"
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip build


### PR DESCRIPTION
A matrix of versions should be tested, if this were an ideal world.

[1] https://github.com/daniperez/vale-python-package/actions/runs/9774002657/job/26981331355